### PR TITLE
Remove mogon references #27

### DIFF
--- a/slides/Snakemake_HPC_Creators.tex
+++ b/slides/Snakemake_HPC_Creators.tex
@@ -19,8 +19,7 @@
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% 
-\begin{frame}[plain] % plain erzeugt Titelseite ohne Kopf- und Fußzeile
-	\MyDatROWS
+\begin{frame}[plain] % plain creates a title page without header or footer
   \titlepage
 \end{frame}
 

--- a/slides/common/Reports.tex
+++ b/slides/common/Reports.tex
@@ -93,10 +93,8 @@ rule bwa_map:
   \end{warning}
 \end{frame}
 
-
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \subsection{Reporting}
-
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{frame}[fragile]
@@ -106,11 +104,6 @@ rule bwa_map:
 $ snakemake --report
   \end{lstlisting}
   This will generate a file called ``\altverb{report.html}'', which you can visualize with a browser.
-  \pause
-  %TODO adjust, once working
-  \begin{alertblock}{Viewing the Report}
-   Due to a bug on \mogon: Copy the file to your computer and visualize it in your browser!
-  \end{alertblock}
 \end{frame} 
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/slides/common/preamble.tex
+++ b/slides/common/preamble.tex
@@ -320,10 +320,10 @@ showstringspaces=false}
 \newcommand{\rmnum}[1]{\romannumeral #1}
 \newcommand{\Rmnum}[1]{\expandafter\@slowromancap\romannumeral #1@}
 \makeatother
-\usepackage{xspace}
-\newcommand{\mogon}{\textsc{mogon}\xspace}
-\newcommand{\mogonI}{\textsc{mogon}\,\Rmnum{1}\xspace}
-\newcommand{\mogonII}{\textsc{mogon}\,\Rmnum{2}\xspace}
+%\usepackage{xspace}
+%\newcommand{\mogon}{\textsc{mogon}\xspace}
+%\newcommand{\mogonI}{\textsc{mogon}\,\Rmnum{1}\xspace}
+%\newcommand{\mogonII}{\textsc{mogon}\,\Rmnum{2}\xspace}
 
 % this package provides the option to read parameters from a configuration file
 \usepackage{readarray}

--- a/slides/common/preamble.tex
+++ b/slides/common/preamble.tex
@@ -320,10 +320,6 @@ showstringspaces=false}
 \newcommand{\rmnum}[1]{\romannumeral #1}
 \newcommand{\Rmnum}[1]{\expandafter\@slowromancap\romannumeral #1@}
 \makeatother
-%\usepackage{xspace}
-%\newcommand{\mogon}{\textsc{mogon}\xspace}
-%\newcommand{\mogonI}{\textsc{mogon}\,\Rmnum{1}\xspace}
-%\newcommand{\mogonII}{\textsc{mogon}\,\Rmnum{2}\xspace}
 
 % this package provides the option to read parameters from a configuration file
 \usepackage{readarray}

--- a/slides/common/software_environment.tex
+++ b/slides/common/software_environment.tex
@@ -1,3 +1,4 @@
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \section{Software Environment}
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -12,7 +13,6 @@
 		\end{column}
 	\end{columns}
 \end{frame}
-
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{frame}
@@ -90,18 +90,17 @@ $ module spider <search string>
   \end{task}
 \end{frame}
 
-%TODO: this slides works with the naming scheme on Mogon - not necessarily on other clusters
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{frame}[fragile]
-   {Modules with easybuild\newline Or: What is this fuzz at the end of module names?}
-   You will have seen modules like:
+  \frametitle{Module Naming Schemes}
+   You might have seen module names like:
    \begin{lstlisting}[language=Bash, style=Shell]
 numlib/FFTW/3.3.10-gompi-2021b   
    \end{lstlisting}
+   Actual module naming schemes differ from cluster to cluster.
    \pause
-   \begin{block}{Easybuild Naming Scheme}
-    We are building our modules with \lhref{https://easybuilders.github.io/easybuild/}{easybuild} and adopted the following naming scheme for modules:\newline
-    \footnotesize \verb+<topic>/<name>/<version>-<toolchain>-<toolchain-version>+
+   \begin{block}{Using Modules with \texttt{Snakemake}}
+     We will learn how to use modules with 
    \end{block}
    \pause
    \begin{task}[Look inside a module to know what will be loaded and set]
@@ -109,13 +108,12 @@ numlib/FFTW/3.3.10-gompi-2021b
    \end{task}
 \end{frame}
 
-%TODO: should we offer more or less on modules?
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%% 
 \begin{frame}[fragile]
   \frametitle{That's all Folks}
    \vspace{-0.8em}
   \begin{alertblock}{Why we will not go in depth now}
-You can learn more about modules in 101-HPC courses. Later, we will learn how to use \texttt{Snakemake} workflows, particularly curated ones, available on the web. We \emph{could} re-write and adapt them for Mogon, it is better to only parameterize them for Mogon and do leave the workflow itself unaltered. This is less cumbersome and as workflow systems, including \texttt{Snakemake}, rely on Conda, we will have an in-depth intro to Conda, instead.
+You can learn more about modules in 101-HPC courses. Later, we will learn how to use \texttt{Snakemake} workflows, particularly curated ones, available on the web. We \emph{could} re-write and adapt them for a specific cluster, it is better to only parameterize them and do leave the workflow itself unaltered, portable. This is less cumbersome and as workflow systems, including \texttt{Snakemake}, rely on Conda, we will have an in-depth intro to Conda, instead.
   \end{alertblock}
   \vfill
   \begin{alertblock}{Do not mix Conda with Modules}

--- a/slides/creators/Decorating_the_Workflow.tex
+++ b/slides/creators/Decorating_the_Workflow.tex
@@ -386,8 +386,8 @@ $ du -sh *reads
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{frame}[fragile]
   \frametitle{Executor Selection}
-  \texttt{Snakemake} lets you select various executors. Not happy with \mogon? Take another cluster or \lhref{https://snakemake.readthedocs.io/en/stable/executor_tutorial/tutorial.html}{Google Lifescience, Tibanna, Kubernetes, \ldots} \newline
-  We may happily select the most prominent HPC batch system, the one running on \mogon, too:
+  \texttt{Snakemake} lets you select various executors. Not happy with HPC clusters? Pay for a cloud \lhref{https://snakemake.readthedocs.io/en/stable/executor_tutorial/tutorial.html}{Google Lifescience, Tibanna, Kubernetes, \ldots} \newline
+  Meanwhile we select the most prominent HPC batch system by:
   \begin{lstlisting}[language=Bash, style=Shell]
 $ snakemake --slurm
   \end{lstlisting}

--- a/slides/creators/Finishing_and_Execution.tex
+++ b/slides/creators/Finishing_and_Execution.tex
@@ -161,7 +161,7 @@ $ snakemake -j4 --forcerun
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{frame}[fragile]
   \frametitle{\HandsOn{Visualising the Output}}
-  On \mogon{} the linux distro is CentOS (or now AlmaLinux), which provides the \altverb{display}-program to display simple images. We shall invoke:
+  On Mogon the Linux distro is CentOS (or now AlmaLinux), which provides the \altverb{display}-program to display simple images. We shall invoke:
   \begin{lstlisting}[language=Bash, style=Shell]
 $ display plots/quals.svg
   \end{lstlisting}


### PR DESCRIPTION
Making this material as far as possible agnostic to the cluster in use. This PR removes all references to Mogon in Mainz (except for the configurable ones). See issue #27 