### PR TITLE
Make date configurable #58

### DIFF
--- a/slides/common/preamble.tex
+++ b/slides/common/preamble.tex
@@ -371,7 +371,6 @@ showstringspaces=false}
 %TODO: What should the subtitle be like? Should there be an Edition? How to keep track?
 \subtitle{Workflow Course - Edition 3} 
 \author[Snakemake Teaching Alliance]{The "Snakemake Teaching Alliance"}
-% TODO: make date configurable
 \date{\configparam{date}}
 
 \hypersetup{colorlinks,linkcolor=,urlcolor=links}

--- a/slides/common/preamble.tex
+++ b/slides/common/preamble.tex
@@ -371,8 +371,8 @@ showstringspaces=false}
 %TODO: What should the subtitle be like? Should there be an Edition? How to keep track?
 \subtitle{Workflow Course - Edition 3} 
 \author[Snakemake Teaching Alliance]{The "Snakemake Teaching Alliance"}
-% TODO: How do we insert a date, which is up to date? Should we insert one, here?
-\date{September 2023}
+% TODO: make date configurable
+\date{\configparam{date}}
 
 \hypersetup{colorlinks,linkcolor=,urlcolor=links}
 

--- a/slides/config/config.dat
+++ b/slides/config/config.dat
@@ -1,11 +1,18 @@
 editorfile = "common/editor_gedit_mainz.tex"
+%
 % The next line indicates the slides explaining
 % a condarc file on a cluster, copy and adjust
 % for your cluster.
+%
 condarcfile = "common/condarc_mogon.tex"
+%
 % these are the path names to contain sample data
 % see the README for explanations.
->>>>>>> main
+%
 pathtoexercise = "/lustre/project/hpckurs/workflows/"
 pathtoclozure = "/lustre/project/hpckurs/cloze/"
 pathtosolution = "/lustre/project/hpckurs/solutions/"
+%
+% date of presentation
+%
+date = "\today"


### PR DESCRIPTION
fix #58 

1. add config param: `date = "\today"` (for flexibility, but can/should be adapted)
2. use `\configparam{date}` in preamble
3. clean up `>>>>>>>>` remnant in config.dat
4. remove `TODO` from preamble