### PR TITLE
adjusted all Snakemake occurences to new typesetting, some typo fixes

### DIFF
--- a/slides/Further_Functionality.tex
+++ b/slides/Further_Functionality.tex
@@ -18,9 +18,9 @@
 \begin{frame}
   \frametitle{What is this about?}
    \begin{question}[Questions]
-   	 \begin{itemize}
-        \item How do we keep \texttt{Snakemake} from submitting non-resource intensive jobs?
-        \item How do we deal with intermediate files?
+     \begin{itemize}
+          \item How do we keep \Snakemake{} from submitting non-resource intensive jobs?
+          \item How do we deal with intermediate files?
      \end{itemize}
    \end{question}
    \begin{docs}[Objectives]

--- a/slides/Snakemake_HPC_Users.tex
+++ b/slides/Snakemake_HPC_Users.tex
@@ -7,7 +7,7 @@
 % to typeset only a few slide sets, set them here during development
 %\includeonly{Why_Workflows}
 
-\include{common/preamble}
+\input{common/preamble}
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -30,10 +30,10 @@
 \include{common/software_environment}
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-%\include{users/Selecting_Workflows}
+\include{users/Selecting_Workflows}
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-%\include{common/Using_Workflow_Configs}
+\include{common/Using_Workflow_Configs}
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \include{common/Plotting_DAGs}
@@ -42,12 +42,12 @@
 \include{common/HPC_101}
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-%\include{common/Workflow_Parametizing_for_HPC}
+\include{common/Workflow_Parametizing_for_HPC}
       
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \include{common/Reports}    
       
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-%\include{common/Contributing} % TODO: should include reporting issues
+\include{common/Contributing} 
 \end{document}
 

--- a/slides/common/HPC_101.tex
+++ b/slides/common/HPC_101.tex
@@ -158,7 +158,7 @@ $ sbatch hello_world.sh
   \end{block}
   \pause
   \begin{hint}[What's next]
-    We are going to parameterize our workflow\textbf{s} for clusters and for our applications in \texttt{Snakemake}!
+      We are going to parameterize our workflow\textbf{s} for clusters and for our applications in \Snakemake!
   \end{hint}
 \end{frame}
 

--- a/slides/common/Plotting_DAGs.tex
+++ b/slides/common/Plotting_DAGs.tex
@@ -24,7 +24,7 @@
    \end{question}
    \begin{docs}[Objectives]
    	  \begin{enumerate} 
-                      \item Learn to plot workflows using \texttt{Snakemake} and \texttt{GraphViz}.
+                      \item Learn to plot workflows using \Snakemake{} and GraphViz.
       \end{enumerate}
    \end{docs}
 \end{frame}
@@ -32,7 +32,7 @@
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{frame}[fragile]
   \frametitle{\HandsOn{Plotting the Workflow}}
-  \texttt{Snakemake} has a build-in plotting feature. Run 
+  \Snakemake{} has a build-in plotting feature. Run 
   \begin{lstlisting}[language=Bash, style=Shell]
 $ snakemake --rulegraph | dot -Tpng > <your_workflow.png>
   \end{lstlisting}

--- a/slides/common/Reports.tex
+++ b/slides/common/Reports.tex
@@ -26,7 +26,7 @@
    \begin{docs}[Objectives]
    	  \begin{enumerate}
          \item Learn the implications and limitations of benchmarks.
-         \item Learning how to generate and interprate reports with \texttt{Snakemake}.
+         \item Learning how to generate and interpret reports with \Snakemake{}.
       \end{enumerate}
   \end{docs}
 \end{frame}
@@ -53,7 +53,7 @@
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{frame}[fragile]
   \frametitle{Generating Benchmarks}
-  Similar to crating a logfile, we are provided with a \altverb{benchmark}-directive, which can point to a bechmarking file:
+  Similar to crating a logfile, we are provided with a \altverb{benchmark}-directive, which can point to a benchmarking file:
   \begin{lstlisting}[language=Python,style=Python]
 rule bwa_map:
     ...
@@ -64,7 +64,7 @@ rule bwa_map:
     ...
   \end{lstlisting} 
   \begin{docs}
-  	\texttt{Snakemake} will measure the wall clock time and memory usage (in MiB) and store it in the file in tab-delimited format.
+  	\Snakemake{} will measure the wall clock time and memory usage (in MiB) and store it in the file in tab-delimited format.
   \end{docs}
 \end{frame}
 
@@ -73,7 +73,7 @@ rule bwa_map:
   \frametitle{Repeating Benchmarks}
   \vfill
   \begin{exampleblock}{Repeated benchmarks}
-   It is possible to repeat a benchmark multiple times in order to get a sense for the variability of the measurements. This can be done by annotating the benchmark file, e.\,g., with \altverb{repeat("benchmarks/\{sample\}.bwa.benchmark.txt", 3)}. \texttt{Snakemake} can be told to run the job three times. The repeated measurements occur as subsequent lines in the tab-delimited benchmark file.
+   It is possible to repeat a benchmark multiple times in order to get a sense for the variability of the measurements. This can be done by annotating the benchmark file, e.\,g., with \altverb{repeat("benchmarks/\{sample\}.bwa.benchmark.txt", 3)}. \Snakemake{} can be told to run the job three times. The repeated measurements occur as subsequent lines in the tab-delimited benchmark file.
   \end{exampleblock}
   \vfill
 \end{frame} 
@@ -89,7 +89,7 @@ rule bwa_map:
   \end{itemize}
   \pause
   \begin{warning}
-  	We conclude: \texttt{Snakemake}'s benchmarking capabilities are limited!
+  	We conclude: \Snakemake{}'s benchmarking capabilities are limited!
   \end{warning}
 \end{frame}
 
@@ -98,8 +98,8 @@ rule bwa_map:
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{frame}[fragile]
-  \frametitle{\texttt{Snakemake} Reports}
-  Asking \texttt{Snakemake} for a report on a completed workflow is as easy as:
+  \frametitle{\Snakemake{} Reports}
+  Asking \Snakemake{} for a report on a completed workflow is as easy as:
   \begin{lstlisting}[language=Bash, style=Shell]
 $ snakemake --report
   \end{lstlisting}
@@ -108,10 +108,10 @@ $ snakemake --report
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{frame}
-  \frametitle{\texttt{Snakemake} Reports and Cluster Jobs}
+  \frametitle{\Snakemake{} Reports and Cluster Jobs}
   \begin{alertblock}{Why reports about Cluster Jobs can be misleading.}
-    When reporting about a cluster or cloud job, \texttt{Snakemake} sheperd job on the login-node will measure the wall time from submit time to the finish time, not the executing job(s).\newline
-    This means: Times can be greatly exegerated!
+    When reporting about a cluster or cloud job, \Snakemake{} shepherd job on the login-node will measure the wall time from submit time to the finish time, not the executing job(s).\newline
+    This means: Times can be greatly exaggerated!
   \end{alertblock}
 \end{frame} 
 

--- a/slides/common/Workflow_Parameterization_for_HPC.tex
+++ b/slides/common/Workflow_Parameterization_for_HPC.tex
@@ -26,8 +26,8 @@
    \begin{docs}[Objectives]
    	 \begin{enumerate} 
         \item Learn to use parameters relevant for the batch systems.
-        \item Learn how to tune \texttt{Snakemake} on the command line.
-        \item Learn how to tune \texttt{Snakemake} with configuration files.
+        \item Learn how to tune \Snakemake{} on the command line.
+        \item Learn how to tune \Snakemake{} with configuration files.
     \end{enumerate}
   \end{docs}
 \end{frame}

--- a/slides/common/editor_gedit_mainz.tex
+++ b/slides/common/editor_gedit_mainz.tex
@@ -100,7 +100,7 @@ $ bg
     \end{column}
     \begin{column}{.5\textwidth}
       \includegraphics[height=3cm]{editors_and_IDEs/gedit.png}	\newline
-      If you want to turn on syntax highlighting for \texttt{Snakefile}s, you have to select \texttt{Python3} as the language. (We will do this, when we hit\texttt{Snakefile}s for the first time.)
+        If you want to turn on syntax highlighting for \altverb{Snakefile}s, you have to select \texttt{Python3} as the language. (We will do this, when we hit\altverb{Snakefile}s for the first time.)
     \end{column} 
   \end{columns}
   \begin{hint}[Note]

--- a/slides/common/preamble.tex
+++ b/slides/common/preamble.tex
@@ -380,7 +380,8 @@ showstringspaces=false}
 \subtitle{Workflow Course - Edition 3} 
 
 \author[Snakemake Teaching Alliance]{The "Snakemake Teaching Alliance"}
-\date{\configparam{date}}
+%\date{\configparam{date}}
+\date{23. September 2023}
 
 \hypersetup{colorlinks,linkcolor=,urlcolor=links}
 

--- a/slides/common/software_environment.tex
+++ b/slides/common/software_environment.tex
@@ -99,7 +99,7 @@ numlib/FFTW/3.3.10-gompi-2021b
    \end{lstlisting}
    Actual module naming schemes differ from cluster to cluster.
    \pause
-   \begin{block}{Using Modules with \texttt{Snakemake}}
+   \begin{block}{Using Modules with \Snakemake{}}
      We will learn how to use modules with 
    \end{block}
    \pause
@@ -113,7 +113,7 @@ numlib/FFTW/3.3.10-gompi-2021b
   \frametitle{That's all Folks}
    \vspace{-0.8em}
   \begin{alertblock}{Why we will not go in depth now}
-You can learn more about modules in 101-HPC courses. Later, we will learn how to use \texttt{Snakemake} workflows, particularly curated ones, available on the web. We \emph{could} re-write and adapt them for a specific cluster, it is better to only parameterize them and do leave the workflow itself unaltered, portable. This is less cumbersome and as workflow systems, including \texttt{Snakemake}, rely on Conda, we will have an in-depth intro to Conda, instead.
+You can learn more about modules in 101-HPC courses. Later, we will learn how to use \Snakemake{} workflows, particularly curated ones, available on the web. We \emph{could} re-write and adapt them for a specific cluster, it is better to only parameterize them and do leave the workflow itself unaltered, portable. This is less cumbersome and as workflow systems, including \Snakemake{}, rely on Conda, we will have an in-depth intro to Conda, instead.
   \end{alertblock}
   \vfill
   \begin{alertblock}{Do not mix Conda with Modules}
@@ -325,11 +325,11 @@ minimap                     0.2_r124      h5bf99c6_4  bioconda
           \item \emph{one} environment per workflow
           \item the environment named as the workflow
           \item this way, we have a bundle of tools, activate the environment for it
-          \item \texttt{snakemake} workflows will install the tools you need for a particular workflow - only \emph{if} these tools are still missing
+          \item \Snakemake{} workflows will install the tools you need for a particular workflow - only \emph{if} these tools are still missing
          \end{itemize}
   \end{hint}
   \begin{hint}[Note]
-  	For now we will not use \texttt{snakemake} to install our software. This topic will be covered later.
+  	For now we will not use \Snakemake{} to install our software. This topic will be covered later.
   \end{hint}
 \end{frame}
 

--- a/slides/config/config.dat
+++ b/slides/config/config.dat
@@ -15,4 +15,4 @@ pathtosolution = "/lustre/project/hpckurs/solutions/"
 %
 % date of presentation
 %
-date = "\today"
+%date = "\today"

--- a/slides/creators/A_First_Workflow.tex
+++ b/slides/creators/A_First_Workflow.tex
@@ -33,12 +33,12 @@
 \begin{frame}[fragile]
   \frametitle{Before we begin \ldots}
   \begin{exampleblock}{Working with closure Files}
-    To ease the excercises and save typing time, all excercises are supplied as cloze texts.\linebreak
-    \texttt{Snakemake} relies on a file called \texttt{Snakefile} to be present. You can either rename your cloze texts like
+    To ease the excercises and save typing time, all exercises are supplied as cloze texts.\linebreak
+    \Snakemake{} relies on a file called \Snakemake{} to be present. You can either rename your cloze texts like
     \begin{lstlisting}[language=Bash, style=Shell]
 $ cp <number>_Snakefile Snakefile
     \end{lstlisting}
-    or specify the workflow file on the commandline with an additional flag:
+    or specify the workflow file on the command line with an additional flag:
     \begin{lstlisting}[language=Bash, style=Shell]
 $ snakemake <other arguments> \
 > --snakefile <number>_Snakefile
@@ -74,7 +74,7 @@ $ snakemake <other arguments> \
     \end{column}
     \begin{column}{0.5\textwidth}
       \begin{hint}
-      	Our long term goal:\newline Have a orderly overview and seperation of data and code. We will start with one \texttt{Snakefile}.
+      	Our long term goal:\newline Have a orderly overview and seperation of data and code. We will start with one \altverb{Snakefile}.
       \end{hint}
     \end{column}
   \end{columns}
@@ -82,7 +82,7 @@ $ snakemake <other arguments> \
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{frame}[fragile]
-  \frametitle{Our first \texttt{Snakefile}!}
+  \frametitle{Our first \altverb{Snakefile}!}
   \begin{onlyenv}<1| handout:0>
     Our first ``\altverb{rule}''; we want to map reads onto a reference genome. 
     \begin{lstlisting}[language=Python,style=Python]
@@ -99,7 +99,7 @@ rule bwa_map:
         " mapped_reads/A.bam"
     \end{lstlisting}
     \begin{docs}
-    	This code is build file, which for \texttt{Snakemake} is called a \texttt{Snakefile} -- a file executed by \texttt{Snakemake}.
+    	This code is build file, which for \Snakemake{} is called a \altverb{Snakefile} -- a file executed by \Snakemake{}.
     \end{docs}
     \end{onlyenv}
   \begin{onlyenv}<2| handout:0>
@@ -154,7 +154,7 @@ rule bwa_map:
     \bcattention Python will concatenate those Strings! Be sure to include spaces to make up a valid command in Bash.
   \end{onlyenv}
   \begin{onlyenv}<5| handout:1>
-   Be sure to have copied everything to your \texttt{Snakefile} and save it.
+   Be sure to have copied everything to your \altverb{Snakefile} and save it.
    \begin{lstlisting}[language=Python,style=Python]
 rule bwa_map:
     input:
@@ -174,7 +174,7 @@ rule bwa_map:
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{frame}
-  \frametitle{\texttt{Snakefile}s are Python Files}
+  \frametitle{\altverb{Snakefile}s are Python Files}
   \begin{block}{Some Background}
      \begin{enumerate}
        \item Like Python, you can use either tabs or spaces for indentation — don’t mix! Consensus is to only use spaces.
@@ -185,12 +185,12 @@ rule bwa_map:
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{frame}[fragile]
-  \frametitle{Testing our \texttt{Snakefile}}
-  When a workflow is executed, \texttt{Snakemake} tries to generate given target files. Target files can be specified via the command line. By executing
+  \frametitle{Testing our \altverb{Snakefile}}
+  When a workflow is executed, \Snakemake{} tries to generate given target files. Target files can be specified via the command line. By executing
   \begin{lstlisting}[language=Bash, style=Shell]
 $ snakemake -np mapped_reads/A.bam
   \end{lstlisting}
-  in the working directory containing the \altverb{Snakefile}, we tell \texttt{Snakemake} to generate the target file \altverb{mapped_reads/A.bam}.\newline
+  in the working directory containing the \altverb{Snakefile}, we tell \Snakemake{} to generate the target file \altverb{mapped_reads/A.bam}.\newline
   We are using 
   \begin{itemize}[<+->]
    \item \altverb{-n/--dry-run} to show the \emph{planned} execution and
@@ -200,13 +200,13 @@ $ snakemake -np mapped_reads/A.bam
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{frame}[fragile]
-  \frametitle{Finally - Running \texttt{Snakemake}!}
-  Now, we can run \texttt{Snakemake}:
+  \frametitle{Finally - Running \Snakemake{}!}
+  Now, we can run \Snakemake{}:
   \begin{lstlisting}[language=Bash, style=Shell]
 $ snakemake --cores=1 mapped_reads/A.bam
   \end{lstlisting}
   \begin{hint}[Note:]
-  	The \altverb{--cores=1} is necessary, because we are executing ``locally'' and \texttt{Snakemake} would like to know how much of the resources we may use (you can try without, though, to see what happens).
+  	The \altverb{--cores=1} is necessary, because we are executing ``locally'' and \Snakemake{} would like to know how much of the resources we may use (you can try without, though, to see what happens).
   \end{hint}
   You should see the expected output (\altverb[Bash]{ls}) and lines which reads:
   \begin{lstlisting}[style=Plain, basicstyle=\footnotesize]
@@ -218,7 +218,7 @@ Complete log: .snakemake/log/2022-09-17T145657.968906.snakemake.log
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{frame}[fragile]
   \frametitle{Re-Running Workflows}
-  Try to run \texttt{Snakemake} again:
+  Try to run \Snakemake{} again:
   \begin{lstlisting}[language=Bash, style=Shell]
 $ snakemake --cores=1 mapped_reads/A.bam
   \end{lstlisting}
@@ -232,7 +232,7 @@ Nothing to be done (all requested files are present and up to date).
   \begin{lstlisting}[language=Bash, style=Shell]
 $ touch mapped_reads/A.bam
   \end{lstlisting}
-  And run \texttt{Snakemake} once more.
+  And run \Snakemake{} once more.
   \begin{question}
   	What happens? Why?
   \end{question}
@@ -241,16 +241,16 @@ $ touch mapped_reads/A.bam
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{frame}
   \frametitle{When do Rules get executed? - The Solution}
-  When it is asked to build a target, \texttt{Snakemake} checks the “last modification time” of both the \emph{target} and its \emph{dependencies}.
+  When it is asked to build a target, \Snakemake{} checks the “last modification time” of both the \emph{target} and its \emph{dependencies}.
   If either
   \begin{itemize}
    \item any dependency has been updated
    \item or a job failed to produce a target (completely)
   \end{itemize}
-  upon re-run \texttt{Snakemake} will only rebuild the files that, either directly or indirectly, depend on the file that changed. This is called an \emph{incremental build}.
+  upon re-run \Snakemake{} will only rebuild the files that, either directly or indirectly, depend on the file that changed. This is called an \emph{incremental build}.
   \pause
   \begin{docs}
-  	By explicitly recording the inputs to and outputs from steps in our analysis and the dependencies between files, Snakefiles act as a type of documentation, reducing the number of things we have to remember.
+  	By explicitly recording the inputs to and outputs from steps in our analysis and the dependencies between files, \altverb{Snakefile}s act as a type of documentation, reducing the number of things we have to remember.
   \end{docs}
 \end{frame}
 
@@ -290,14 +290,14 @@ rule bwa_map:
         " | samtools view -Sb - >"
         " {output}"
     \end{lstlisting}
-    Since the rule has multiple input files, \texttt{Snakemake} will concatenate them, separated by a whitespace. In other words, \texttt{Snakemake} will replace \altverb{\{input\}} with \altverb{data/genome.fa data/samples/A.fastq} before executing the command.\newline
+    Since the rule has multiple input files, \Snakemake{} will concatenate them, separated by a whitespace. In other words, \Snakemake{} will replace \altverb{\{input\}} with \altverb{data/genome.fa data/samples/A.fastq} before executing the command.\newline
     A working example can be found in \altverb{02_Snakefile}.
 \end{frame}
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{frame}[fragile]
   \frametitle{Further Workflow Decoration}\footnotesize 
-  \texttt{Snakemake} allows generalizing rules by using named wildcards. Simply replace the \altverb{A} in the second input file and in the output file with the wildcard \altverb{\{sample\}}, to yield:
+  \Snakemake{} allows generalizing rules by using named wildcards. Simply replace the \altverb{A} in the second input file and in the output file with the wildcard \altverb{\{sample\}}, to yield:
   \begin{lstlisting}[language=Python,style=Python,basicstyle=\footnotesize]
 rule bwa_map:
     input:
@@ -308,7 +308,7 @@ rule bwa_map:
     shell:
         "bwa mem {input} | samtools view -Sb - > {output}"
   \end{lstlisting}
-  When \texttt{Snakemake} determines that this rule can be applied to generate a target file by replacing the wildcard \altverb{\{sample\}} in the output file with an appropriate value, it will propagate that value to all occurrences of \altverb{\{sample\}} in the input files and thereby determine the necessary input for the resulting job. 
+  When \Snakemake{} determines that this rule can be applied to generate a target file by replacing the wildcard \altverb{\{sample\}} in the output file with an appropriate value, it will propagate that value to all occurrences of \altverb{\{sample\}} in the input files and thereby determine the necessary input for the resulting job. 
 \end{frame}
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -326,7 +326,7 @@ rule bwa_map:
   \begin{lstlisting}[language=Bash, style=Shell]
 $ snakemake -np mapped_reads/B.bam
   \end{lstlisting}
-  \texttt{Snakemake} will determine that the rule \altverb{bwa_map} can be applied to generate the target file by replacing the wildcard \altverb{\{sample\}} with the value \altverb{B}.\newline
+  \Snakemake{} will determine that the rule \altverb{bwa_map} can be applied to generate the target file by replacing the wildcard \altverb{\{sample\}} with the value \altverb{B}.\newline
   To analyse samples \altverb{A} and \altverb{B}, we can specify two targets
     \begin{lstlisting}[language=Bash, style=Shell]
 $ snakemake -np mapped_reads/A.bam mapped_reads/B.bam
@@ -363,11 +363,11 @@ rule samtools_sort:
   The rule will take  input file from the \altverb{mapped_reads} directory and store a sorted version in the \altverb{sorted_reads} directory.
   \pause
   \begin{docs}
-  	\texttt{Snakemake} will automatically create missing directories!
+  	\Snakemake{} will automatically create missing directories!
   \end{docs}
   You noticed \altverb{-T sorted_reads/\{wildcards.sample\}}?
   \pause
-  For sorting, \texttt{samtools} requires a prefix specified with the flag \altverb{-T}. Here, we need the value of the wildcard \altverb{sample}. \texttt{Snakemake} allows to access wildcards in the shell command via the wildcards object that has an attribute with the value for each wildcard.
+  For sorting, \texttt{samtools} requires a prefix specified with the flag \altverb{-T}. Here, we need the value of the wildcard \altverb{sample}. \Snakemake{} allows to access wildcards in the shell command via the wildcards object that has an attribute with the value for each wildcard.
 \end{frame}
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -377,7 +377,7 @@ rule samtools_sort:
   \begin{lstlisting}[language=Bash, style=Shell]
 $ snakemake -np sorted_reads/B.bam
   \end{lstlisting}
-  you will notice that \texttt{Snakemake} wants to run the first rule \altverb{bwa_map} and then the rule \altverb{samtools_sort} to create the desired target file.
+  you will notice that \Snakemake{} wants to run the first rule \altverb{bwa_map} and then the rule \altverb{samtools_sort} to create the desired target file.
   \begin{docs}
   	Dependencies are resolved automatically by matching file names.
   \end{docs}
@@ -405,7 +405,7 @@ rule samtools_index:
 \begin{frame}[fragile]
  \frametitle{Calling Genomic Variants - Background I}
  The next step in our workflow will aggregate the mapped reads from all samples and jointly call genomic variants on them. We need two tools: \lhref{https://www.htslib.org/}{samtools} and \lhref{https://www.htslib.org/}{bcftools}. \newline \pause
- \texttt{Snakemake} provides a helper function for collecting input files that helps us to describe the aggregation in this step. With
+ \Snakemake{} provides a helper function for collecting input files that helps us to describe the aggregation in this step. With
  \begin{lstlisting}[language=Python,style=Python]
 expand("sorted_reads/{sample}.bam", sample=SAMPLES)
  \end{lstlisting}

--- a/slides/creators/Decorating_the_Workflow.tex
+++ b/slides/creators/Decorating_the_Workflow.tex
@@ -41,7 +41,7 @@
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{frame}
   \begin{docs}
-  	\texttt{Snakemake} has an extensive command line interface (CLI). \emph{Everything} can be configured on the command line. In addition (almost) everything can be specified in a configuration file.
+  	\Snakemake{} has an extensive command line interface (CLI). \emph{Everything} can be configured on the command line. In addition (almost) everything can be specified in a configuration file.
   \end{docs}
   \pause
   \begin{exampleblock}{Which parameter goes where? Some rules of thumb:}
@@ -71,8 +71,8 @@
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{frame}[fragile]
-  \frametitle{The \texttt{Snakemake} \texttt{resources} Section}
-  \texttt{Snakemake} rules provide an additional \altverb{resource} section:
+  \frametitle{The \Snakemake{} \texttt{resources} Section}
+  \Snakemake{} rules provide an additional \altverb{resource} section:
   \begin{lstlisting}[language=Python,style=Python]
 rule <name>:
    ...
@@ -92,13 +92,13 @@ rule <name>:
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{frame}
-  \frametitle{The \texttt{Snakemake} \texttt{resources} Section - its Downside}
+  \frametitle{The \Snakemake{} \texttt{resources} Section - its Downside}
   \begin{block}{Every Resource Spec needs a Change per Rule???}
-   You might have noticed, this specification per rule is most untidy. \texttt{Snakemake}'s design principle is: ship workflows which run \emph{everywhere} \& \emph{every time}.
+   You might have noticed, this specification per rule is most untidy. \Snakemake's design principle is: ship workflows which run \emph{everywhere} \& \emph{every time}.
    \newline \pause
    Relax: Every bit we can specify:
    \begin{itemize}
-    \item in a \texttt{Snakefile},
+    \item in a \altverb{Snakefile},
     \item on the command line,
     \item and re-usable in configuration files!
    \end{itemize}
@@ -136,12 +136,12 @@ rule <name>:
   \begin{lstlisting}[language=Bash, style=Shell]
 $ snakemake ... --configfile ./config/config.yaml  
   \end{lstlisting}
-  Or, alternatively in your \texttt{Snakefile}:
+  Or, alternatively in your \altverb{Snakefile}:
   \begin{lstlisting}[language=Python,style=Python]
 configfile: "config.yaml"
   \end{lstlisting}  
   \begin{question}
-  	How do pick up resource parameters in out \texttt{Snakefile}?!
+  	How do pick up resource parameters in out \altverb{Snakefile}?!
   \end{question}
 \end{frame} 
 
@@ -149,7 +149,7 @@ configfile: "config.yaml"
 \begin{frame}[fragile]
   \frametitle{Working with Configuration Data}
   \begin{hint}
-  	Remember: \texttt{Snakefile}s are Python files.
+  	Remember: \altverb{Snakefile}s are Python files.
   \end{hint}
   \pause
   Given a file \altverb{config.yaml} with contents:
@@ -198,7 +198,7 @@ rule bcftools_call:
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{frame}[fragile]
   \frametitle{Input Functions}
-  Since we have stored the path to the FASTQ files in the config file, we can also generalize the rule \altverb{bwa_map} to use these paths. This case is different to the rule \altverb{bcftools_call} we modified above. To understand this, it is important to know that \texttt{Snakemake} workflows are executed in three phases.
+  Since we have stored the path to the FASTQ files in the config file, we can also generalize the rule \altverb{bwa_map} to use these paths. This case is different to the rule \altverb{bcftools_call} we modified above. To understand this, it is important to know that \Snakemake{} workflows are executed in three phases.
   \begin{itemize}[<+->]
    \item In the \emph{initialization phase}, the files defining the workflow are parsed and all rules are instantiated.
    \item In the \emph{DAG phase}, the directed acyclic dependency graph of all jobs is built by filling wildcards and matching input files to output files.
@@ -226,11 +226,11 @@ rule bwa_map:
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{frame}[fragile]
   \frametitle{\HandsOn{Adding a new Sample}}
-  In the \altverb{data/samples} folder, there is an additional sample \altverb{C.fastq}. Add that sample to the config file and see how \texttt{Snakemake} wants to recompute the part of the workflow belonging to the new sample, when invoking with 
+  In the \altverb{data/samples} folder, there is an additional sample \altverb{C.fastq}. Add that sample to the config file and see how \Snakemake{} wants to recompute the part of the workflow belonging to the new sample, when invoking with 
   \begin{lstlisting}[language=Bash, style=Shell]
 $ snakemake -n --forcerun bcftools_call
   \end{lstlisting}
-  Copy the file XXX as your \texttt{Snakefile}. 
+  Copy the file XXX as your \altverb{Snakefile}. 
 \end{frame}
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -293,7 +293,7 @@ rule bwa_map:
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{frame}[fragile]
   \frametitle{Logging - II}
-  \texttt{Snakemake} offers a \altverb{log}-directive for this purpose.  
+  \Snakemake{} offers a \altverb{log}-directive for this purpose.  
   \begin{lstlisting}[language=Python,style=Python]
 rule bwa_map:
     input:
@@ -328,7 +328,7 @@ rule bwa_map:
 \begin{frame}[fragile]
   \frametitle{Temporary Files}
   Let's face it: Most output files of a workflow, particularly more complex ones(!), do not need to be archived. They will only take up storage until someone takes the \includegraphics[height=\baselineskip]{misc/broom.png}.\newline
-  Luckily, \texttt{Snakemake} provides a way to mark a file as ``temporary'' and will delete it, when its not needed any longer.
+  Luckily, \Snakemake{} provides a way to mark a file as ``temporary'' and will delete it, when its not needed any longer.
   \pause
   \begin{question}
   	The output of which rules in our workflow should be marked ``temporary''?
@@ -354,7 +354,7 @@ rule bwa_map:
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{frame}[fragile]
   \frametitle{\HandsOn{Temporary Files - Put to Work}}
-  \texttt{Snakemake}s way to mark outputs as temporary or intermediate is the \altverb{temp()}-function, e.\,g.:
+  \Snakemake{}s way to mark outputs as temporary or intermediate is the \altverb{temp()}-function, e.\,g.:
   \begin{lstlisting}[language=Python,style=Python]
 rule bwa_map:
     input:
@@ -386,7 +386,7 @@ $ du -sh *reads
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{frame}[fragile]
   \frametitle{Executor Selection}
-  \texttt{Snakemake} lets you select various executors. Not happy with HPC clusters? Pay for a cloud \lhref{https://snakemake.readthedocs.io/en/stable/executor_tutorial/tutorial.html}{Google Lifescience, Tibanna, Kubernetes, \ldots} \newline
+  \Snakemake{} lets you select various executors. Not happy with HPC clusters? Pay for a cloud \lhref{https://snakemake.readthedocs.io/en/stable/executor_tutorial/tutorial.html}{Google Lifescience, Tibanna, Kubernetes, \ldots} \newline
   Meanwhile we select the most prominent HPC batch system by:
   \begin{lstlisting}[language=Bash, style=Shell]
 $ snakemake --slurm
@@ -400,7 +400,7 @@ $ snakemake --slurm
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{frame}[fragile]
   \frametitle{Default Resources for \texttt{SLURM}}
-  Without specifying our SLURM-account and a (default) partition, submitting batch jobs will fail. \texttt{Snakemake} allows to define so-called default resources (using \altverb{--default-resources}). With them our minimal command line becomes:
+  Without specifying our SLURM-account and a (default) partition, submitting batch jobs will fail. \Snakemake{} allows to define so-called default resources (using \altverb{--default-resources}). With them our minimal command line becomes:
   \begin{lstlisting}[language=Bash, style=Shell, basicstyle=\footnotesize]
 $ snakemake --slurm \
 > --default-resources slurm_account=m2_jgu-ngstraining \
@@ -423,7 +423,7 @@ $ snakemake --slurm \
    \item may hold jobs pending until resources are available!
   \end{itemize}
   \pause
-  \texttt{Snakemake} offers a semaphore to throttle resource usage, called \altverb{--jobs/-j}. We can now write \altverb{-j unlimited} in place for \altverb{--cores 1}. Let us try
+  \Snakemake{} offers a semaphore to throttle resource usage, called \altverb{--jobs/-j}. We can now write \altverb{-j unlimited} in place for \altverb{--cores 1}. Let us try
   \begin{lstlisting}[language=Bash, style=Shell, basicstyle=\footnotesize]
 $ snakemake --slurm \
 > --default-resources \ 
@@ -436,8 +436,8 @@ $ snakemake --slurm \
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{frame}[fragile]
-  \frametitle{\texttt{SLURM} supporting Features of \texttt{Snakemake}}
-  \texttt{Snakemake} will
+  \frametitle{\texttt{SLURM} supporting Features of \Snakemake{}}
+  \Snakemake{} will
   \begin{itemize}[<+->]
    \item hold track of your job status (frequency of checks can be adjusted)
    \item cancel your jobs, when itself is stopped
@@ -487,7 +487,7 @@ $ snakemake --slurm \
   \begin{hint}
   	Best abstract the configuration for a cluster from the workflow!
   \end{hint}
-  In addition to a \altverb{config} directory to hold our samples, \texttt{Snakemake} will accept a directory with profile settings, usually ``\altverb{profile}''.
+  In addition to a \altverb{config} directory to hold our samples, \Snakemake{} will accept a directory with profile settings, usually ``\altverb{profile}''.
   \pause
   A profile has to adhere to \lhref{https://en.wikipedia.org/wiki/YAML}{\texttt{YAML}-format} and be named \altverb{config.yaml}. An example for a cluster configuration might look like (sorry, no syntax highlighting available):
   \begin{lstlisting}[style=Plain]
@@ -498,7 +498,7 @@ set-resources:
   \end{lstlisting}
   \pause
   
-  \texttt{Snakemake} \lhref{https://snakemake.readthedocs.io/en/stable/executing/cluster.htmls}{offers many more cluster configuration details}, we will revisit some during this course.
+  \Snakemake{} \lhref{https://snakemake.readthedocs.io/en/stable/executing/cluster.htmls}{offers many more cluster configuration details}, we will revisit some during this course.
 
 \end{frame}
 
@@ -533,7 +533,7 @@ $ snakemake --slurm \
    \item rules which include remote files (e.\,g. to an archive)
   \end{enumerate}
   \pause
-  For such a purpose \texttt{Snakemake} offer the \altverb{localrules} directive.
+  For such a purpose \Snakemake{} offers the \altverb{localrules} directive.
   \begin{lstlisting}[language=Python,style=Python]
 # its useage is (at or near the top of a Snakefile)
 localrules: rule_a, rule_b, rule_c, ...
@@ -548,7 +548,7 @@ localrules: rule_a, rule_b, rule_c, ...
   \begin{lstlisting}[language=Python,style=Python]
 localrules: plot_quals
   \end{lstlisting}
-  at the top of your \texttt{Snakefile} and rerun the workflow on this cluster.
+  at the top of your \Snakemake{} and rerun the workflow on this cluster.
   \pause
   \begin{question}
   	Which is the impact on the overall execution time?

--- a/slides/creators/Finishing_and_Execution.tex
+++ b/slides/creators/Finishing_and_Execution.tex
@@ -36,8 +36,8 @@
   \frametitle{Why Target Rules}
   So far, we always executed the workflow by specifying a target file at the command line. How cumbersome!\newline
   \begin{docs}
-  	We remember: \texttt{Snakemake} will automatically determine for a given rule, which expected outcomes are missing and execute all necessary rules, accordingly.\newline\pause
-        The ``trick'' is that a workflow can have a ``target'' rule, which specifies the \emph{final} output(s) of a workflow. Any invokation of \texttt{Snakemake} will then execute \emph{all} rules of a workflow.
+  	We remember: \Snakemake{} will automatically determine for a given rule, which expected outcomes are missing and execute all necessary rules, accordingly.\newline\pause
+        The ``trick'' is that a workflow can have a ``target'' rule, which specifies the \emph{final} output(s) of a workflow. Any invokation of \Snakemake{} will then execute \emph{all} rules of a workflow.
    \end{docs}
 \end{frame}
 
@@ -45,7 +45,7 @@
 \begin{frame}[fragile]
   \frametitle{Best Practice}
   \begin{docs}
-  	If no target is given at the command line, \texttt{Snakemake} will define the first rule of the \texttt{Snakefile} as the target.
+  	If no target is given at the command line, \Snakemake{} will define the first rule of the \altverb{Snakefile} as the target.
   \end{docs}
   Conventially, this rule is named \altverb{all}. This means that we add a rule at the top of our workflow:\newline
   \begin{onlyenv}<1| handout:0>

--- a/slides/creators/Python_in_Snakemake.tex
+++ b/slides/creators/Python_in_Snakemake.tex
@@ -36,11 +36,11 @@
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{frame}
-  \frametitle{Why Python in \texttt{Snakefile}?}
+  \frametitle{Why Python in a \altverb{Snakefile}?}
   Sometimes we do \emph{not} want to run $3^{\mathsf{rd}}$ party code, but run the occasional script for data manipulation   or plotting or \ldots 
   \pause
   \begin{docs}
-  	\texttt{Snakefile}s are Python code (albeit special Python code)!)
+  	\altverb{Snakefile}s are Python code (albeit special Python code)!)
   \end{docs}
 \end{frame}
 
@@ -49,7 +49,7 @@
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{frame}[fragile]
-  \frametitle{Using functions in \texttt{Snakefile}s}
+  \frametitle{Using functions in \altverb{Snakefile}s}
   We already met the \altverb{expand()}-function. Let's revisit it in detail!
   \begin{task}
   	Start Python and follow along!
@@ -57,7 +57,7 @@
   \begin{lstlisting}[language=Python,style=Python]
 from snakemake.io import expand, glob_wildcards
   \end{lstlisting}
-   \altverb{expand()} is used frequently, to expand a \texttt{Snakemake} wildcard(s) into a set of filenames:
+   \altverb{expand()} is used frequently, to expand a \Snakemake{} wildcard(s) into a set of filenames:
   \begin{lstlisting}[language=Python,style=Python]
 >>> expand('folder/{wildcard1}_{wildcard2}.txt',
 ...        wildcard1=['a', 'b', 'c'],
@@ -67,7 +67,7 @@ from snakemake.io import expand, glob_wildcards
 
 % %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{frame}[fragile]
-  \frametitle{Using functions in \texttt{Snakefile}s II}
+  \frametitle{Using functions in \altverb{Snakefile}s II}
   \begin{question}
   	What is the result?
   \end{question}
@@ -117,7 +117,7 @@ glob_wildcards('data/samples/{replicas}.fastq').replicas
 \begin{frame}[fragile]
   \frametitle{\Interlude{Meeting the \texttt{run} Action}}
   \vspace{-0.5em}
-  It is possible to run Python snippets in \texttt{Snakemake}. For this, we have to replace the \altverb{shell:} action by a \altverb{run:} action:\vspace{-0.5em}
+  It is possible to run Python snippets in \Snakemake{}. For this, we have to replace the \altverb{shell:} action by a \altverb{run:} action:\vspace{-0.5em}
   \begin{task}
   	Imaging this code in a \altverb{Snakefile}:
   \end{task}\vspace{-0.5em}
@@ -144,13 +144,13 @@ rule print_sample_names:
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{frame}[fragile]
-  \frametitle{\texttt{Snakemake} Specials for Python}
+  \frametitle{\Snakemake{} Specials for Python}
   Remember this part:
   \begin{lstlisting}[language=Python,style=Python]
 shell:  'some_command -i {input} -o {output}'
   \end{lstlisting}
   \begin{question}
-  	Isn't this rather tedious, considering that \texttt{Snakemake} is written in Python? Could we forward rule specific information to our scripts?
+  	Isn't this rather tedious, considering that \Snakemake{} is written in Python? Could we forward rule specific information to our scripts?
   \end{question}
 \end{frame}
 
@@ -158,8 +158,8 @@ shell:  'some_command -i {input} -o {output}'
 \setbeamertemplate{footline}{}
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{frame}[fragile]
-  \frametitle{\texttt{Snakemake}'s features for external Scripts}
-  In addition to the \altverb{shell} and \altverb{run} directives, \texttt{Snakemake} offers a \altverb{script} directive, too:
+  \frametitle{\Snakemake's features for external Scripts}
+  In addition to the \altverb{shell} and \altverb{run} directives, \Snakemake{} offers a \altverb{script} directive, too:
   \begin{lstlisting}[language=Python,style=Python]
 rule NAME:
     input:
@@ -195,7 +195,7 @@ do_something(snakemake@input[[1]], snakemake@output[[1]])
 \begin{frame}[fragile]
   \frametitle{\Interlude{Debugging external Scripts}}
   \begin{exampleblock}{Debugging Python Scripts}
-  To debug Python scripts, you can invoke \texttt{Snakemake} with
+  To debug Python scripts, you can invoke \Snakemake{} with
   \begin{lstlisting}[language=Bash, style=Shell]
 $ snakemake --debug
   \end{lstlisting}
@@ -203,7 +203,7 @@ $ snakemake --debug
   \end{exampleblock}
   \pause
   \begin{exampleblock}{Debugging R Scripts}
-  To debug R scripts, you can save the workspace with \altverb{save.image()}, and invoke R after \texttt{Snakemake} has terminated. 
+  To debug R scripts, you can save the workspace with \altverb{save.image()}, and invoke R after \Snakemake{} has terminated. 
   \end{exampleblock}
 \end{frame}
 

--- a/slides/users/Selecting_Workflows.tex
+++ b/slides/users/Selecting_Workflows.tex
@@ -30,12 +30,12 @@
     \end{docs}
 \end{frame}  
 
-\subsection{The \texttt{Snakemake} Workflow Catalogue}
+\subsection{The Snakemake Workflow Catalogue}
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \begin{frame}
  \frametitle{Selecting and Downloading from the Workflow Catalogue}
- You can find the \texttt{Snakemake} worfkflow catalogue, \lhref{https://snakemake.github.io/snakemake-workflow-catalog/?rules=true}{here}. It makes a difference between workflows which meet best-practice criteria - and those which do not.\newline
+ You can find the \Snakemake{} worfkflow catalogue, \lhref{https://snakemake.github.io/snakemake-workflow-catalog/?rules=true}{here}. It makes a difference between workflows which meet best-practice criteria - and those which do not.\newline
  \begin{columns}
    \begin{column}{0.5\textwidth}
      You can download and run any workflow. \pause\newline


### PR DESCRIPTION
Following the merge of PR #49 all occurrences of Snakemake needed adjustment, too.

The merge of #58 had to be revoked. It gave a number of syntax breaks. Ultimately, a new PDF generation with jinja2 would be a remedy: This current config file setup is not sustainable. 